### PR TITLE
Make compatible with TF v0.13+

### DIFF
--- a/releases/2.0/modules/heracles/01-tags.tf
+++ b/releases/2.0/modules/heracles/01-tags.tf
@@ -1,7 +1,7 @@
 # Define our common tags.
 locals {
-  common_tags = "${map(
-    "HeraclesClusterName", "${var.cluster_name}",
-    "HeraclesClusterID", "${var.cluster_id}"
-  )}"
+  common_tags = "${tomap({
+    "HeraclesClusterName"= "${var.cluster_name}",
+    "HeraclesClusterID"= "${var.cluster_id}"
+  })}"
 }

--- a/releases/2.0/modules/heracles/03-vpc.tf
+++ b/releases/2.0/modules/heracles/03-vpc.tf
@@ -6,9 +6,9 @@ resource "aws_vpc" "heracles" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}"
-    )
+    tomap({
+      "Name" = "${var.cluster_id}"
+    })
   )
 }
 
@@ -19,9 +19,9 @@ resource "aws_internet_gateway" "heracles" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-igw"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-igw"
+    })
   )
 }
 
@@ -36,9 +36,9 @@ resource "aws_subnet" "public-subnet" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-pub"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-pub"
+    })
   )
 }
 
@@ -54,9 +54,9 @@ resource "aws_route_table" "public" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-prt"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-prt"
+    })
   )
 }
 

--- a/releases/2.0/modules/heracles/04-security-groups.tf
+++ b/releases/2.0/modules/heracles/04-security-groups.tf
@@ -22,9 +22,9 @@ resource "aws_security_group" "heracles-vpc" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-sg"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-sg"
+    })
   )
 }
 
@@ -70,9 +70,9 @@ resource "aws_security_group" "heracles-public-ingress" {
     # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-ingress"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-ingress"
+    })
   )
 }
 
@@ -94,9 +94,9 @@ resource "aws_security_group" "heracles-public-egress" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-egress"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-egress"
+    })
   )
 }
 
@@ -117,8 +117,8 @@ resource "aws_security_group" "heracles-ssh" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-ssh"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-ssh"
+    })
   )
 }

--- a/releases/2.0/modules/heracles/06-control.tf
+++ b/releases/2.0/modules/heracles/06-control.tf
@@ -15,9 +15,9 @@ resource "aws_eip" "control_eip" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-control-eip"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-control-eip"
+    })
   )   
 }
 
@@ -41,9 +41,10 @@ resource "aws_instance" "control" {
     volume_type = "gp2"
     tags = merge(
       local.common_tags,
-      map(
-        "Name", "${var.cluster_id}-control-root"
-      )
+      tomap({
+        "Name"= "${var.cluster_id}-control-root"
+      })
+
     )    
   }  
 
@@ -52,8 +53,8 @@ resource "aws_instance" "control" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-control"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-control"
+    })
   )
 }

--- a/releases/2.0/modules/heracles/07-nginx.tf
+++ b/releases/2.0/modules/heracles/07-nginx.tf
@@ -15,9 +15,9 @@ resource "aws_eip" "nginx_eip" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-nginx-eip"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-nginx-eip"
+    })
   )   
 }
 
@@ -42,9 +42,9 @@ resource "aws_instance" "nginx" {
     volume_type = "gp2"
     tags = merge(
       local.common_tags,
-      map(
-        "Name", "${var.cluster_id}-nginx-root"
-      )
+      tomap({
+        "Name"= "${var.cluster_id}-nginx-root"
+      })
     )    
   }  
 
@@ -53,8 +53,8 @@ resource "aws_instance" "nginx" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-nginx"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-nginx"
+    })
   )
 }

--- a/releases/2.0/modules/heracles/08-spring.tf
+++ b/releases/2.0/modules/heracles/08-spring.tf
@@ -18,9 +18,9 @@ resource "aws_eip" "spring_eip" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-spring-${count.index + 1}-eip"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-spring-${count.index + 1}-eip"
+    })
   )  
 }
 
@@ -46,9 +46,9 @@ resource "aws_instance" "spring" {
     volume_type = "gp2"
     tags = merge(
       local.common_tags,
-      map(
-        "Name", "${var.cluster_id}-spring-${count.index + 1}-root"
-      )
+      tomap({
+        "Name"= "${var.cluster_id}-spring-${count.index + 1}-root"
+      })
     )    
   }
 
@@ -59,9 +59,9 @@ resource "aws_instance" "spring" {
   #   volume_type = "gp2"
   #   tags = merge(
   #     local.common_tags,
-  #     map(
-  #       "Name", "${var.cluster_id}-spring-${count.index + 1}-data"
-  #     )
+  #     tomap({
+  #       "Name"= "${var.cluster_id}-spring-${count.index + 1}-data"
+  #     })
   #   )     
   # }
 
@@ -70,8 +70,8 @@ resource "aws_instance" "spring" {
   //  Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-spring-${count.index + 1}"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-spring-${count.index + 1}"
+    })
   )
 }

--- a/releases/2.0/modules/heracles/09-mysql.tf
+++ b/releases/2.0/modules/heracles/09-mysql.tf
@@ -15,9 +15,9 @@ resource "aws_eip" "mysql_eip" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-mysql-eip"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-mysql-eip"
+    })
   )   
 }
 
@@ -41,9 +41,9 @@ resource "aws_instance" "mysql" {
     volume_type = "gp2"
     tags = merge(
       local.common_tags,
-      map(
-        "Name", "${var.cluster_id}-mysql-root"
-      )
+      tomap({
+        "Name"= "${var.cluster_id}-mysql-root"
+      })
     )    
   }  
 
@@ -52,8 +52,8 @@ resource "aws_instance" "mysql" {
   # Use our common tags and add a specific name.
   tags = merge(
     local.common_tags,
-    map(
-      "Name", "${var.cluster_id}-mysql"
-    )
+    tomap({
+      "Name"= "${var.cluster_id}-mysql"
+    })
   )
 }

--- a/releases/2.0/providers.tf
+++ b/releases/2.0/providers.tf
@@ -1,10 +1,20 @@
 #
+# Version constraints for Providers
+#
+terraform {
+  required_providers {
+    aws = {
+      version = ">= 2.38.0"
+    }
+  }
+}
+
+#
 # Provider Configuration
 #
 
 provider "aws" {
   region  = "us-east-2"
-  version = ">= 2.38.0"
 }
 
 # Using these data sources allows the configuration to be

--- a/releases/2.0/versions.tf
+++ b/releases/2.0/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Changes:
- Minor changes - replace map() with tomap()
- Add Terraform version requirement and set it to >=0.13
- Fix warning for future deprecated functionality

I haven´t tested if this still work on v0.12 as I don´t have that version nor have Hashicorp documented in what version tomap() was introduced.

All in all this remove future module version constraints having to be maintained as newer modules will stop working with ancient TF versions over time